### PR TITLE
refactor (WavefrontOBJWriter): transform Unity mesh vertices/normals from left-handedness to right-handedness and invert primitive index order

### DIFF
--- a/Runtime/WavefrontOBJWriter.cs
+++ b/Runtime/WavefrontOBJWriter.cs
@@ -1,12 +1,19 @@
 using System;
 using System.Linq;
 using System.Text;
+using Unity.Mathematics;
 using UnityEngine;
 
 namespace FrozenAPE
 {
     public class WavefrontOBJWriter : IWavefrontOBJWriter
     {
+        /// <summary>
+        /// Unity is using a left-handed coordinate system
+        /// whereas OBJ expects right-handed coordinates.
+        /// </summary>
+        static double4x4 kmLeftToRightHandedness = math.double4x4(-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+
         public virtual StringBuilder WriteOBJ(string name, Mesh mesh, Material[] materials, StringBuilder sb)
         {
             sb.AppendLine($"o {name}");
@@ -17,7 +24,9 @@ namespace FrozenAPE
             sb.AppendLine().AppendLine("# vertices");
             foreach (var v in mesh.vertices)
             {
-                sb.AppendLine($"v {v.x} {v.y} {v.z}");
+                var v_lh = math.double3(v);
+                var v_rh = math.mul(kmLeftToRightHandedness, math.double4(v_lh, 1)).xyz;
+                sb.AppendLine($"v {v_rh.x} {v_rh.y} {v_rh.z}");
             }
 
             sb.AppendLine().AppendLine("# normals");

--- a/Runtime/WavefrontOBJWriter.cs
+++ b/Runtime/WavefrontOBJWriter.cs
@@ -79,7 +79,7 @@ namespace FrozenAPE
                 for (int i = 0; i < desc.indexCount; i += elementsPerLine)
                 {
                     sb.Append($"{faceTag}");
-                    for (int x = 0; x < elementsPerLine; x++)
+                    for (int x = elementsPerLine - 1; x >= 0; x--)
                     {
                         int faceIndex = 1 + mesh.triangles[desc.indexStart + i + x]; // indices are 1 based
                         sb.Append($" {faceIndex}/{faceIndex}/{faceIndex}"); //< indices in order `v/vt/vn`

--- a/Runtime/WavefrontOBJWriter.cs
+++ b/Runtime/WavefrontOBJWriter.cs
@@ -13,6 +13,11 @@ namespace FrozenAPE
         /// whereas OBJ expects right-handed coordinates.
         /// </summary>
         static double4x4 kmLeftToRightHandedness = math.double4x4(-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+        static double3x3 kmLeftToRightHandedness_normal = math.double3x3(
+            kmLeftToRightHandedness.c0.xyz,
+            kmLeftToRightHandedness.c1.xyz,
+            kmLeftToRightHandedness.c2.xyz
+        );
 
         public virtual StringBuilder WriteOBJ(string name, Mesh mesh, Material[] materials, StringBuilder sb)
         {
@@ -32,7 +37,9 @@ namespace FrozenAPE
             sb.AppendLine().AppendLine("# normals");
             foreach (var vn in mesh.normals)
             {
-                sb.AppendLine($"vn {vn.x} {vn.y} {vn.z}");
+                var vn_lh = math.double3(vn);
+                var vn_rh = math.mul(kmLeftToRightHandedness_normal, vn_lh);
+                sb.AppendLine($"vn {vn_rh.x} {vn_rh.y} {vn_rh.z}");
             }
 
             sb.AppendLine().AppendLine("# texcoords");


### PR DESCRIPTION
- **refactor (WavefrontOBJWriter): transform Unity vertices from left-handedness to right-handedness before writing them**
- **refactor (WavefrontOBJWriter): transform Unity normals from left-handedness to right-handedness before writing them**
- **refactor (WavefrontOBJWriter): invert order of primitive indices to fit right-handed vertex/normal coordinates**
