### PR TITLE
refactor (WavefrontOBJWriter): simplify vertex/normal transforms to right-handedness to float computations

### DIFF
--- a/Runtime/WavefrontOBJWriter.cs
+++ b/Runtime/WavefrontOBJWriter.cs
@@ -13,7 +13,7 @@ namespace FrozenAPE
         /// whereas OBJ expects right-handed coordinates.
         /// </summary>
         static float4x4 kmLeftToRightHandedness = math.float4x4(-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
-        static double3x3 kmLeftToRightHandedness_normal = math.double3x3(
+        static float3x3 kmLeftToRightHandedness_normal = math.float3x3(
             kmLeftToRightHandedness.c0.xyz,
             kmLeftToRightHandedness.c1.xyz,
             kmLeftToRightHandedness.c2.xyz
@@ -36,8 +36,7 @@ namespace FrozenAPE
             sb.AppendLine().AppendLine("# normals");
             foreach (var vn in mesh.normals)
             {
-                var vn_lh = math.double3(vn);
-                var vn_rh = math.mul(kmLeftToRightHandedness_normal, vn_lh);
+                var vn_rh = math.mul(kmLeftToRightHandedness_normal, vn);
                 sb.AppendLine($"vn {vn_rh.x} {vn_rh.y} {vn_rh.z}");
             }
 

--- a/Runtime/WavefrontOBJWriter.cs
+++ b/Runtime/WavefrontOBJWriter.cs
@@ -12,7 +12,7 @@ namespace FrozenAPE
         /// Unity is using a left-handed coordinate system
         /// whereas OBJ expects right-handed coordinates.
         /// </summary>
-        static double4x4 kmLeftToRightHandedness = math.double4x4(-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+        static float4x4 kmLeftToRightHandedness = math.float4x4(-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
         static double3x3 kmLeftToRightHandedness_normal = math.double3x3(
             kmLeftToRightHandedness.c0.xyz,
             kmLeftToRightHandedness.c1.xyz,
@@ -29,8 +29,7 @@ namespace FrozenAPE
             sb.AppendLine().AppendLine("# vertices");
             foreach (var v in mesh.vertices)
             {
-                var v_lh = math.double3(v);
-                var v_rh = math.mul(kmLeftToRightHandedness, math.double4(v_lh, 1)).xyz;
+                var v_rh = math.mul(kmLeftToRightHandedness, math.float4(v, 1)).xyz;
                 sb.AppendLine($"v {v_rh.x} {v_rh.y} {v_rh.z}");
             }
 


### PR DESCRIPTION
- **refactor (WavefrontOBJWriter): simplify vertex transform to right-handedness to float computation**
  reason: was using double precision, whereas mesh data is single precision. No need to upcast.
  

- **refactor (WavefrontOBJWriter): simplify normal transform to right-handedness to float computation**
  reason: was using double precision, whereas mesh data is single precision. No need to upcast.
  