### PR TITLE
refactor (WavefrontOBJWriter): simplify vertex/normal handedness transforms to mere vector multiplications

### DIFF
--- a/Runtime/WavefrontOBJWriter.cs
+++ b/Runtime/WavefrontOBJWriter.cs
@@ -13,11 +13,6 @@ namespace FrozenAPE
         /// whereas OBJ expects right-handed coordinates.
         /// </summary>
         static float3 kvLeftToRightHandedness = math.float3(-1, 1, 1);
-        static float3x3 kmLeftToRightHandedness_normal = math.float3x3(
-            kmLeftToRightHandedness.c0.xyz,
-            kmLeftToRightHandedness.c1.xyz,
-            kmLeftToRightHandedness.c2.xyz
-        );
 
         public virtual StringBuilder WriteOBJ(string name, Mesh mesh, Material[] materials, StringBuilder sb)
         {
@@ -36,7 +31,7 @@ namespace FrozenAPE
             sb.AppendLine().AppendLine("# normals");
             foreach (var vn in mesh.normals)
             {
-                var vn_rh = math.mul(kmLeftToRightHandedness_normal, vn);
+                var vn_rh = kvLeftToRightHandedness * vn;
                 sb.AppendLine($"vn {vn_rh.x} {vn_rh.y} {vn_rh.z}");
             }
 

--- a/Runtime/WavefrontOBJWriter.cs
+++ b/Runtime/WavefrontOBJWriter.cs
@@ -12,7 +12,7 @@ namespace FrozenAPE
         /// Unity is using a left-handed coordinate system
         /// whereas OBJ expects right-handed coordinates.
         /// </summary>
-        static float4x4 kmLeftToRightHandedness = math.float4x4(-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+        static float3 kvLeftToRightHandedness = math.float3(-1, 1, 1);
         static float3x3 kmLeftToRightHandedness_normal = math.float3x3(
             kmLeftToRightHandedness.c0.xyz,
             kmLeftToRightHandedness.c1.xyz,
@@ -29,7 +29,7 @@ namespace FrozenAPE
             sb.AppendLine().AppendLine("# vertices");
             foreach (var v in mesh.vertices)
             {
-                var v_rh = math.mul(kmLeftToRightHandedness, math.float4(v, 1)).xyz;
+                var v_rh = kvLeftToRightHandedness * v;
                 sb.AppendLine($"v {v_rh.x} {v_rh.y} {v_rh.z}");
             }
 


### PR DESCRIPTION
- **refactor (WavefrontOBJWriter): simplify vertex handedness transform to a mere vector multiplication**
  reason: matrix multiplication is overkill for this.
  

- **refactor (WavefrontOBJWriter): simplify normal handedness transform to a mere vector multiplication**
  reason: matrix multiplication is overkill for this.
  