### PR TITLE
refactor (ci workflows): replace GH_NPM_TOKEN with internal package-write GITHUB_TOKEN in test-npm/npm jobs

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -55,7 +55,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
           - source: npmjs
             registry-url: https://registry.npmjs.org/
             scope: 'kagekirin'                        #must be lowercase, without '@'

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -44,6 +44,9 @@ jobs:
   test-npm:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -50,7 +50,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
           - source: npmjs
             registry-url: https://registry.npmjs.org/
             scope: 'kagekirin'                        #must be lowercase, without '@'

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -39,6 +39,9 @@ jobs:
 
   test-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -53,7 +53,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
           - source: npmjs
             registry-url: https://registry.npmjs.org/
             scope: 'kagekirin'                        #must be lowercase, without '@'

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -42,6 +42,9 @@ jobs:
 
   test-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   test-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
           - source: npmjs
             registry-url: https://registry.npmjs.org/
             scope: 'kagekirin'                        #must be lowercase, without '@'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,9 @@ jobs:
 
   npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         source: [github, npmjs]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
-            token: GH_NPM_TOKEN
+            token: GITHUB_TOKEN
           - source: npmjs
             registry-url: https://registry.npmjs.org/
             scope: 'kagekirin'                        #must be lowercase, without '@'


### PR DESCRIPTION
- **refactor ('build-pr' workflow): add package-write permissions to 'test-npm' job**
- **refactor ('build-ci' workflow): add package-write permissions to 'test-npm' job**
- **refactor ('build-cron' workflow): add package-write permissions to 'test-npm' job**
- **refactor ('publish' workflow): add package-write permissions to 'test-npm' job**
- **refactor ('publish' workflow): add package-write permissions to 'npm' job**
- **refactor ('build-pr' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'test-npm' job**
- **refactor ('build-ci' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'test-npm' job**
- **refactor ('build-cron' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'test-npm' job**
- **refactor ('publish' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'test-npm' job**
- **refactor ('publish' workflow): replace GH_NPM_TOKEN with internal GITHUB_TOKEN in 'npm' job**
