### PR TITLE
refactor (Runtime): simplify IWavefrontMTLWriter.WriteMTL() and IWavefrontOBJWriter.WriteOBJ() interfaces

### DIFF
--- a/Editor/FrozenAPE.Menu.cs
+++ b/Editor/FrozenAPE.Menu.cs
@@ -58,14 +58,10 @@ namespace FrozenAPE
                     }
 
                     var materials = meshRenderer != null ? meshRenderer.sharedMaterials : Array.Empty<Material>();
-                    var sbObj = objWriter.WriteOBJ(
-                        Path.GetFileNameWithoutExtension(targetPathObj),
-                        meshFilter.sharedMesh,
-                        materials,
-                        new StringBuilder()
-                    );
+                    var obj = objWriter.WriteOBJ(Path.GetFileNameWithoutExtension(targetPathObj), meshFilter.sharedMesh, materials);
+                    File.WriteAllText(targetPathObj, obj);
+
                     var sbMtl = mtlWriter.WriteMTL(Path.GetFileNameWithoutExtension(targetPathMtl), materials, new StringBuilder());
-                    File.WriteAllText(targetPathObj, sbObj.ToString());
                     File.WriteAllText(targetPathMtl, sbMtl.ToString());
                 }
 
@@ -98,18 +94,17 @@ namespace FrozenAPE
                         continue;
                     }
 
-                    var sbObj = objWriter.WriteOBJ(
+                    var obj = objWriter.WriteOBJ(
                         Path.GetFileNameWithoutExtension(targetPathObj),
                         skinnedMeshRenderer.sharedMesh,
-                        skinnedMeshRenderer.sharedMaterials,
-                        new StringBuilder()
+                        skinnedMeshRenderer.sharedMaterials
                     );
                     var sbMtl = mtlWriter.WriteMTL(
                         Path.GetFileNameWithoutExtension(targetPathMtl),
                         skinnedMeshRenderer.sharedMaterials,
                         new StringBuilder()
                     );
-                    File.WriteAllText(targetPathObj, sbObj.ToString());
+                    File.WriteAllText(targetPathObj, obj);
                     File.WriteAllText(targetPathMtl, sbMtl.ToString());
                 }
                 return;
@@ -125,13 +120,8 @@ namespace FrozenAPE
                     return;
                 }
 
-                var sbObj = objWriter.WriteOBJ(
-                    Path.GetFileNameWithoutExtension(targetPathObj),
-                    mesh,
-                    Array.Empty<Material>(),
-                    new StringBuilder()
-                );
-                File.WriteAllText(targetPathObj, sbObj.ToString());
+                var obj = objWriter.WriteOBJ(Path.GetFileNameWithoutExtension(targetPathObj), mesh, Array.Empty<Material>());
+                File.WriteAllText(targetPathObj, obj);
                 return;
             }
         }

--- a/Editor/FrozenAPE.Menu.cs
+++ b/Editor/FrozenAPE.Menu.cs
@@ -59,10 +59,9 @@ namespace FrozenAPE
 
                     var materials = meshRenderer != null ? meshRenderer.sharedMaterials : Array.Empty<Material>();
                     var obj = objWriter.WriteOBJ(Path.GetFileNameWithoutExtension(targetPathObj), meshFilter.sharedMesh, materials);
+                    var mtl = mtlWriter.WriteMTL(Path.GetFileNameWithoutExtension(targetPathMtl), materials);
                     File.WriteAllText(targetPathObj, obj);
-
-                    var sbMtl = mtlWriter.WriteMTL(Path.GetFileNameWithoutExtension(targetPathMtl), materials, new StringBuilder());
-                    File.WriteAllText(targetPathMtl, sbMtl.ToString());
+                    File.WriteAllText(targetPathMtl, mtl);
                 }
 
                 foreach (var skinnedMeshRenderer in go.GetComponentsInChildren<SkinnedMeshRenderer>(true))
@@ -99,13 +98,9 @@ namespace FrozenAPE
                         skinnedMeshRenderer.sharedMesh,
                         skinnedMeshRenderer.sharedMaterials
                     );
-                    var sbMtl = mtlWriter.WriteMTL(
-                        Path.GetFileNameWithoutExtension(targetPathMtl),
-                        skinnedMeshRenderer.sharedMaterials,
-                        new StringBuilder()
-                    );
+                    var mtl = mtlWriter.WriteMTL(Path.GetFileNameWithoutExtension(targetPathMtl), skinnedMeshRenderer.sharedMaterials);
                     File.WriteAllText(targetPathObj, obj);
-                    File.WriteAllText(targetPathMtl, sbMtl.ToString());
+                    File.WriteAllText(targetPathMtl, mtl);
                 }
                 return;
             }

--- a/Runtime/IWavefrontMTLWriter.cs
+++ b/Runtime/IWavefrontMTLWriter.cs
@@ -1,11 +1,10 @@
 using System;
-using System.Text;
 using UnityEngine;
 
 namespace FrozenAPE
 {
     public interface IWavefrontMTLWriter
     {
-        StringBuilder WriteMTL(string name, Material[] materials, StringBuilder sb);
+        string WriteMTL(string name, Material[] materials);
     }
 }

--- a/Runtime/IWavefrontMTLWriter.cs
+++ b/Runtime/IWavefrontMTLWriter.cs
@@ -5,6 +5,12 @@ namespace FrozenAPE
 {
     public interface IWavefrontMTLWriter
     {
+        /// <summary>
+        /// create the MTL (ascii) material library from supplied materials
+        /// </summary>
+        /// <param name="name">name given to this material library. Note: it must match the name provided to the OBJ file as well as the filename written to disc</param>
+        /// <param name="materials">array of Unity Material data, usually obtained from `MeshRenderer.sharedMaterials` or `SkinnedMeshRenderer.sharedMaterials`</param>
+        /// <returns>string containing the MTL (ascii) material library</returns>
         string WriteMTL(string name, Material[] materials);
     }
 }

--- a/Runtime/IWavefrontOBJWriter.cs
+++ b/Runtime/IWavefrontOBJWriter.cs
@@ -1,11 +1,10 @@
 using System;
-using System.Text;
 using UnityEngine;
 
 namespace FrozenAPE
 {
     public interface IWavefrontOBJWriter
     {
-        StringBuilder WriteOBJ(string name, Mesh mesh, Material[] materials, StringBuilder sb);
+        string WriteOBJ(string name, Mesh mesh, Material[] materials);
     }
 }

--- a/Runtime/IWavefrontOBJWriter.cs
+++ b/Runtime/IWavefrontOBJWriter.cs
@@ -5,6 +5,13 @@ namespace FrozenAPE
 {
     public interface IWavefrontOBJWriter
     {
+        /// <summary>
+        /// create the OBJ (ascii) representation from supplied mesh and materials
+        /// </summary>
+        /// <param name="name">name given to this model. Note: it must match the name provided to the MTL file as well as the filename written to disc</param>
+        /// <param name="mesh">Unity Mesh data, usually obtained from `MeshFilter.sharedMesh` or `SkinnedMeshRenderer.sharedMesh`</param>
+        /// <param name="materials">array of Unity Material data, usually obtained from `MeshRenderer.sharedMaterials` or `SkinnedMeshRenderer.sharedMaterials`</param>
+        /// <returns>string containing the OBJ (ascii) representation</returns>
         string WriteOBJ(string name, Mesh mesh, Material[] materials);
     }
 }

--- a/Runtime/WavefrontMTLWriter.cs
+++ b/Runtime/WavefrontMTLWriter.cs
@@ -7,8 +7,9 @@ namespace FrozenAPE
 {
     public class WavefrontMTLWriter : IWavefrontMTLWriter
     {
-        public StringBuilder WriteMTL(string name, Material[] materials, StringBuilder sb)
+        public string WriteMTL(string name, Material[] materials)
         {
+            StringBuilder sb = new();
             sb.AppendLine($"# material lib {name}");
 
             foreach (var mat in materials.Distinct())
@@ -29,7 +30,7 @@ namespace FrozenAPE
                     .AppendLine($"map_Ks {mainTexture.name}.png");
             }
 
-            return sb;
+            return sb.ToString();
         }
     }
 }

--- a/Runtime/WavefrontOBJWriter.cs
+++ b/Runtime/WavefrontOBJWriter.cs
@@ -8,8 +8,9 @@ namespace FrozenAPE
 {
     public class WavefrontOBJWriter : IWavefrontOBJWriter
     {
-        public virtual StringBuilder WriteOBJ(string name, Mesh mesh, Material[] materials, StringBuilder sb)
+        public string WriteOBJ(string name, Mesh mesh, Material[] materials)
         {
+            StringBuilder sb = new();
             sb.AppendLine($"o {name}");
 
             sb.AppendLine().AppendLine("# materials");
@@ -73,7 +74,7 @@ namespace FrozenAPE
                 }
             }
 
-            return sb;
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
- **refactor (Runtime): simplify IWavefrontOBJWriter.WriteOBJ() interface**
- **refactor (Runtime): simplify IWavefrontMTLWriter.WriteMTL() interface**
- **doc (Runtime): document IWavefrontOBJWriter interface**
- **doc (Runtime): document IWavefrontMTLWriter interface**
- **refactor (Runtime): adapt WavefrontOBJWriter implementation to changes in IWavefrontOBJWriter interface**
- **refactor (Runtime): adapt WavefrontMTLWriter implementation to changes in IWavefrontMTLWriter interface**
- **refactor (Editor): adapt 'Export OBJ' menu implementation to IWavefrontOBJWriter interface changes**
- **refactor (Editor): adapt 'Export OBJ' menu implementation to IWavefrontMTLWriter interface changes**
