### PR TITLE
chore: silently bump version to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kagekirin.frozenape",
-  "version": "0.0.23",
+  "version": "0.1.0-0",
   "displayName": "Frozen A-Pose Exporter 🧊🦍",
   "description": "Editor and Runtime exporter for skinned meshes frozen in a specific pose as static mesh",
   "unity": "2022.3",


### PR DESCRIPTION
reason: officially releasing to OpenUPM
