### PR TITLE
fix (package.json): fix cause of missing Assembly definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "**/*.meta",
     "**/*.md",
     "**/*.cs",
-    "**/*.amsdef"
+    "**/*.asmdef"
   ],
   "dependencies": {
     "org.nuget.system.componentmodel.annotations": "5.0.0",


### PR DESCRIPTION
fix: correct typo 'amsdef' -> 'asmdef'
