### PR TITLE
refactor (ci workflows): restore NPMJS to test-npm/npm matrix parameters, this time with _empty_ scope

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -49,13 +49,18 @@ jobs:
       packages: write
     strategy:
       matrix:
-        source: [github]
+        source: [github, npmjs]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GITHUB_TOKEN
+          - source: npmjs
+            registry-url: https://registry.npmjs.org
+            scope: ''                                 #must be EMPTY
+            username: ${{ github.repository_owner }}  #not lowercase
+            token: NPMJS_ORG_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -44,13 +44,18 @@ jobs:
       packages: write
     strategy:
       matrix:
-        source: [github]
+        source: [github, npmjs]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GITHUB_TOKEN
+          - source: npmjs
+            registry-url: https://registry.npmjs.org
+            scope: ''                                 #must be EMPTY
+            username: ${{ github.repository_owner }}  #not lowercase
+            token: NPMJS_ORG_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -47,13 +47,18 @@ jobs:
       packages: write
     strategy:
       matrix:
-        source: [github]
+        source: [github, npmjs]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GITHUB_TOKEN
+          - source: npmjs
+            registry-url: https://registry.npmjs.org
+            scope: ''                                 #must be EMPTY
+            username: ${{ github.repository_owner }}  #not lowercase
+            token: NPMJS_ORG_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,18 @@ jobs:
       packages: write
     strategy:
       matrix:
-        source: [github]
+        source: [github, npmjs]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GITHUB_TOKEN
+          - source: npmjs
+            registry-url: https://registry.npmjs.org
+            scope: ''                                 #must be EMPTY
+            username: ${{ github.repository_owner }}  #not lowercase
+            token: NPMJS_ORG_TOKEN
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - id: npm-prepare-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,13 +46,18 @@ jobs:
       packages: write
     strategy:
       matrix:
-        source: [github]
+        source: [github, npmjs]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GITHUB_TOKEN
+          - source: npmjs
+            registry-url: https://registry.npmjs.org
+            scope: ''                                 #must be EMPTY
+            username: ${{ github.repository_owner }}  #not lowercase
+            token: NPMJS_ORG_TOKEN
     needs: test-npm
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main


### PR DESCRIPTION
- **refactor ('build-pr' workflow): restore parameters for 'npmjs' from 'test-npm' job matrix**
  big change to previous failed attempts: this time, the scope is left empty
  

- **refactor ('build-ci' workflow): restore parameters for 'npmjs' from 'test-npm' job matrix**
  big change to previous failed attempts: this time, the scope is left empty
  

- **refactor ('build-cron' workflow): restore parameters for 'npmjs' from 'test-npm' job matrix**
  big change to previous failed attempts: this time, the scope is left empty
  

- **refactor ('publish' workflow): restore parameters for 'npmjs' from 'test-npm' job matrix**
  big change to previous failed attempts: this time, the scope is left empty
  

- **refactor ('publish' workflow): restore parameters for 'npmjs' from 'npm' job matrix**
  big change to previous failed attempts: this time, the scope is left empty
  