### PR TITLE
build (Editor): set assembly definition to auto referenced and Editor-only

### DIFF
--- a/Editor/FrozenAPE.Editor.asmdef
+++ b/Editor/FrozenAPE.Editor.asmdef
@@ -17,7 +17,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Editor/FrozenAPE.Editor.asmdef
+++ b/Editor/FrozenAPE.Editor.asmdef
@@ -2,12 +2,9 @@
     "name": "FrozenAPE.Editor",
     "rootNamespace": "FrozenAPE",
     "references": [
-        "UnityEditor",
-        "UnityEngine.Jobs",
         "Unity.Burst",
         "Unity.Collections",
         "Unity.Collections.BurstCompatibilityGen",
-        "Unity.Jobs",
         "Unity.Mathematics",
         "Unity.RenderPipelines.Core.Runtime",
         "Unity.Serialization",

--- a/Editor/FrozenAPE.Editor.asmdef
+++ b/Editor/FrozenAPE.Editor.asmdef
@@ -10,7 +10,9 @@
         "Unity.Serialization",
         "FrozenAPE"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
- **build (Editor): remove default references**
  reason: entries are greyed out in Unity Editor, meaning the assembly can't be found or is a default assembly
  

- **build (Editor): mark assembly definition as being Editor-only**
  

- **build (Editor): set assembly definition to auto referenced**
  