### PR TITLE
refactor (Runtime): change transform VS Posed Bone comparison in RigVerifier to use custom milli-unit-precision ε

### DIFF
--- a/Runtime/RigVerifier.cs
+++ b/Runtime/RigVerifier.cs
@@ -36,7 +36,7 @@ namespace FrozenAPE
                     matches.Add(match.z);
                     if (!(match.x && match.y && match.z))
                         Debug.LogError(
-                            $"rotation mismatch for {posedBone.targetBone}:"
+                            $"rotation mismatch for {posedBone.targetBone}: {match}"
                                 + $"\n Posed Bone rotation is {posedBone.rotation}"
                                 + $"\n transform rotation is {transform.eulerAngles}"
                         );
@@ -50,7 +50,7 @@ namespace FrozenAPE
                     matches.Add(match.z);
                     if (!(match.x && match.y && match.z))
                         Debug.LogError(
-                            $"position mismatch for {posedBone.targetBone}:"
+                            $"position mismatch for {posedBone.targetBone}: {match}"
                                 + $"\n Posed Bone position is {posedBone.position}"
                                 + $"\n transform position is {transform.position}"
                         );
@@ -64,7 +64,7 @@ namespace FrozenAPE
                     matches.Add(match.z);
                     if (!(match.x && match.y && match.z))
                         Debug.LogError(
-                            $"scaling mismatch for {posedBone.targetBone}:"
+                            $"scaling mismatch for {posedBone.targetBone}: {match}"
                                 + $"\n Posed Bone scaling is {posedBone.scaling}"
                                 + $"\n transform scaling is {transform.localScale}"
                         );

--- a/Runtime/RigVerifier.cs
+++ b/Runtime/RigVerifier.cs
@@ -30,7 +30,7 @@ namespace FrozenAPE
 
                 if (posedBone.rotation is not null)
                 {
-                    var match = (double3)posedBone.rotation! == (double3)(float3)transform.eulerAngles;
+                    var match = math.abs((double3)posedBone.rotation! - (double3)(float3)transform.eulerAngles) <= k_Epsilon;
                     matches.Add(match.x);
                     matches.Add(match.y);
                     matches.Add(match.z);
@@ -44,7 +44,7 @@ namespace FrozenAPE
 
                 if (posedBone.position is not null)
                 {
-                    var match = (double3)posedBone.position! == (double3)(float3)transform.position;
+                    var match = math.abs((double3)posedBone.position! - (double3)(float3)transform.position) <= k_Epsilon;
                     matches.Add(match.x);
                     matches.Add(match.y);
                     matches.Add(match.z);
@@ -58,7 +58,7 @@ namespace FrozenAPE
 
                 if (posedBone.scaling is not null)
                 {
-                    var match = (double3)posedBone.scaling! == (double3)(float3)transform.localScale;
+                    var match = math.abs((double3)posedBone.scaling! - (double3)(float3)transform.localScale) <= k_Epsilon;
                     matches.Add(match.x);
                     matches.Add(match.y);
                     matches.Add(match.z);

--- a/Runtime/RigVerifier.cs
+++ b/Runtime/RigVerifier.cs
@@ -10,6 +10,12 @@ namespace FrozenAPE
 {
     public class RigVerifier : IRigVerifier
     {
+        /// <summary>
+        /// a custom ε (epsilon) b/c both math.EPSILON and math.EPSILON_DBL are too low
+        /// i.e. we want our cutoff at around 10^(-3), milli unit level as anything
+        /// lower doesn't sense make wrt Unity's internal transform precision
+        /// </summary>
+        const double k_Epsilon = 0.001;
         public virtual bool CheckPose(Transform[] transforms, in IEnumerable<PosedBone> posedBones)
         {
             List<bool> matches = new();


### PR DESCRIPTION
- **feature (Runtime): add internal constant RigVerifier.k_Epsilon to define ε at milli-unit precision**
- **refactor (Runtime): change transform VS Posed Bone comparison in RigVerifier to use custom milli-unit-precision ε**
- **refactor (Runtime): log result of comparison to spot mismatched values**
