### PR TITLE
refactor (Runtime): simplify ITextureWriter implementations by inheriting from common abstract base class BaseTextureWriter

### DIFF
--- a/Runtime/BaseTextureWriter.cs
+++ b/Runtime/BaseTextureWriter.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Unity.Collections;
+using UnityEngine;
+using UnityEngine.Assertions;
+using Rendering = UnityEngine.Experimental.Rendering;
+
+namespace FrozenAPE
+{
+    public abstract class BaseTextureWriter : ITextureWriter
+    {
+        public byte[] WriteTexture(Texture texture)
+        {
+            Assert.IsNotNull(texture);
+            NativeArray<byte> imageBytes = default;
+            uint texture_depth = 1;
+
+            if (texture is Texture2D)
+            {
+                imageBytes = (texture as Texture2D).GetPixelData<byte>(mipLevel: 0);
+            }
+            else if (texture is Texture3D)
+            {
+                imageBytes = (texture as Texture3D).GetPixelData<byte>(mipLevel: 0);
+                texture_depth = (uint)(texture as Texture3D).depth;
+            }
+            else if (texture is Texture2DArray)
+            {
+                imageBytes = (texture as Texture2DArray).GetPixelData<byte>(mipLevel: 0, element: 0);
+                texture_depth = (uint)(texture as Texture2DArray).depth;
+            }
+
+            using NativeArray<byte> bytes = EncodingFunc(
+                imageBytes,
+                texture.graphicsFormat,
+                (uint)texture.width,
+                (uint)texture.height * texture_depth,
+                0
+            );
+            return bytes.ToArray();
+        }
+
+        public string NameTexture(Texture texture)
+        {
+            Assert.IsNotNull(texture);
+
+            if (Path.GetExtension(texture.name).ToLowerInvariant() == FileExtension)
+                return texture.name;
+
+            return $"{texture.name}.{FileExtension}";
+        }
+
+        /// <summary>
+        /// the file extension, lowercase without '.'
+        /// </summary>
+        protected abstract string FileExtension { get; }
+
+        /// <summary>
+        /// the encoding function
+        /// signature matches ImageConversion.EncodeNativeArrayTo[PNG|TGA|JPG|EXR]
+        /// </summary>
+        protected abstract Func<
+            NativeArray<byte>, //< raw image bytes
+            Rendering.GraphicsFormat,
+            uint, //< width
+            uint, //< height
+            uint, //< rowBytes
+            NativeArray<byte> //< return
+        > EncodingFunc { get; }
+    }
+}

--- a/Runtime/BaseTextureWriter.cs.meta
+++ b/Runtime/BaseTextureWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7645a05270e86475d977005e645591e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/TextureJPGWriter.cs
+++ b/Runtime/TextureJPGWriter.cs
@@ -2,34 +2,39 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Assertions;
+using Rendering = UnityEngine.Experimental.Rendering;
 
 namespace FrozenAPE
 {
-    public class TextureJPGWriter : ITextureWriter
+    public class TextureJPGWriter : BaseTextureWriter
     {
-        public byte[] WriteTexture(Texture texture)
+        protected override string FileExtension
         {
-            Assert.IsNotNull(texture);
-            Assert.IsTrue(texture is Texture2D, "TextureJPGWriter only supports Texture2D");
-
-            if (texture is Texture2D)
-            {
-                return ImageConversion.EncodeToJPG(texture as Texture2D);
-            }
-
-            return null;
+            get => "jpg";
         }
 
-        public string NameTexture(Texture texture)
+        protected override Func<
+            NativeArray<byte>, //< raw image bytes
+            Rendering.GraphicsFormat,
+            uint, //< width
+            uint, //< height
+            uint, //< rowBytes
+            NativeArray<byte> //< return
+        > EncodingFunc
         {
-            Assert.IsNotNull(texture);
-
-            if (Path.GetExtension(texture.name).ToLowerInvariant() == "jpg")
-                return texture.name;
-
-            return $"{texture.name}.jpg";
+            get =>
+                (NativeArray<byte> rawImageBytes, Rendering.GraphicsFormat graphicsFormat, uint width, uint height, uint rowBytes) =>
+                    ImageConversion.EncodeNativeArrayToJPG(
+                        input: rawImageBytes,
+                        format: graphicsFormat,
+                        width: width,
+                        height: height,
+                        rowBytes: rowBytes,
+                        quality: 100
+                    );
         }
     }
 }

--- a/Runtime/TexturePNGWriter.cs
+++ b/Runtime/TexturePNGWriter.cs
@@ -2,34 +2,30 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Assertions;
+using Rendering = UnityEngine.Experimental.Rendering;
 
 namespace FrozenAPE
 {
-    public class TexturePNGWriter : ITextureWriter
+    public class TexturePNGWriter : BaseTextureWriter
     {
-        public byte[] WriteTexture(Texture texture)
+        protected override string FileExtension
         {
-            Assert.IsNotNull(texture);
-            Assert.IsTrue(texture is Texture2D, "TexturePNGWriter only supports Texture2D");
-
-            if (texture is Texture2D)
-            {
-                return ImageConversion.EncodeToPNG(texture as Texture2D);
-            }
-
-            return null;
+            get => "png";
         }
 
-        public string NameTexture(Texture texture)
+        protected override Func<
+            NativeArray<byte>, //< raw image bytes
+            Rendering.GraphicsFormat,
+            uint, //< width
+            uint, //< height
+            uint, //< rowBytes
+            NativeArray<byte> //< return
+        > EncodingFunc
         {
-            Assert.IsNotNull(texture);
-
-            if (Path.GetExtension(texture.name).ToLowerInvariant() == "png")
-                return texture.name;
-
-            return $"{texture.name}.png";
+            get => ImageConversion.EncodeNativeArrayToPNG;
         }
     }
 }

--- a/Runtime/TextureTGAWriter.cs
+++ b/Runtime/TextureTGAWriter.cs
@@ -2,34 +2,30 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Assertions;
+using Rendering = UnityEngine.Experimental.Rendering;
 
 namespace FrozenAPE
 {
-    public class TextureTGAWriter : ITextureWriter
+    public class TextureTGAWriter : BaseTextureWriter
     {
-        public byte[] WriteTexture(Texture texture)
+        protected override string FileExtension
         {
-            Assert.IsNotNull(texture);
-            Assert.IsTrue(texture is Texture2D, "TextureTGAWriter only supports Texture2D");
-
-            if (texture is Texture2D)
-            {
-                return ImageConversion.EncodeToTGA(texture as Texture2D);
-            }
-
-            return null;
+            get => "tga";
         }
 
-        public string NameTexture(Texture texture)
+        protected override Func<
+            NativeArray<byte>, //< raw image bytes
+            Rendering.GraphicsFormat,
+            uint, //< width
+            uint, //< height
+            uint, //< rowBytes
+            NativeArray<byte> //< return
+        > EncodingFunc
         {
-            Assert.IsNotNull(texture);
-
-            if (Path.GetExtension(texture.name).ToLowerInvariant() == "tga")
-                return texture.name;
-
-            return $"{texture.name}.tga";
+            get => ImageConversion.EncodeNativeArrayToTGA;
         }
     }
 }


### PR DESCRIPTION
- **feature (Runtime): implement base class BaseTextureWriter to partially implement interface ITextureWriter**
- **refactor (TexturePNGWriter): simplify implementation by inheriting from BaseTextureWriter**
- **refactor (TextureTGAWriter): simplify implementation by inheriting from BaseTextureWriter**
- **refactor (TextureJPGWriter): simplify implementation by inheriting from BaseTextureWriter**
