### PR TITLE
refactor (RigPuppeteer): enhance verbosity by logging bone and pose component to be applied

### DIFF
--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -15,7 +15,10 @@ namespace FrozenAPE
             {
                 int idx = Array.FindIndex(transforms, t => t.name == posedBone.targetBone);
                 if (idx < 0)
+                {
+                    Debug.LogWarning($"could not find bone {posedBone.targetBone}. skipping.");
                     continue;
+                }
 
                 if (posedBone.rotation is not null)
                 {

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -37,7 +37,9 @@ namespace FrozenAPE
 
                 if (posedBone.scaling is not null)
                 {
+                    Debug.Log($"\tposing scale {transforms[idx].localScale} to {posedBone.scaling}");
                     transforms[idx].localScale = (Vector3)math.float3((double3)posedBone.scaling!);
+                    Debug.Log($"\tscale is now {transforms[idx].localScale}");
                 }
             }
         }

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -23,7 +23,9 @@ namespace FrozenAPE
                 Debug.Log($"applying pose for bone {posedBone.targetBone} [{transforms[idx].name}]");
                 if (posedBone.rotation is not null)
                 {
+                    Debug.Log($"\tposing rotation {transforms[idx].eulerAngles} to {posedBone.rotation}");
                     transforms[idx].eulerAngles = (Vector3)math.float3((double3)posedBone.rotation!);
+                    Debug.Log($"\trotation is now {transforms[idx].eulerAngles}");
                 }
 
                 if (posedBone.position is not null)

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -30,7 +30,9 @@ namespace FrozenAPE
 
                 if (posedBone.position is not null)
                 {
+                    Debug.Log($"\tposing position {transforms[idx].position} to {posedBone.position}");
                     transforms[idx].position = (Vector3)math.float3((double3)posedBone.position!);
+                    Debug.Log($"\tposition is now {transforms[idx].position}");
                 }
 
                 if (posedBone.scaling is not null)

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -20,6 +20,7 @@ namespace FrozenAPE
                     continue;
                 }
 
+                Debug.Log($"applying pose for bone {posedBone.targetBone} [{transforms[idx].name}]");
                 if (posedBone.rotation is not null)
                 {
                     transforms[idx].eulerAngles = (Vector3)math.float3((double3)posedBone.rotation!);


### PR DESCRIPTION
- **refactor (RigPuppeteer): log warning when bone could not be found**
- **refactor (RigPuppeteer): log bone name before applying pose**
- **refactor (RigPuppeteer): log bone rotation before and after applying pose**
- **refactor (RigPuppeteer): log bone position before and after applying pose**
- **refactor (RigPuppeteer): log bone scale before and after applying pose**
