### PR TITLE
refactor (Runtime): apply pose position and rotation in local space only

### DIFF
--- a/Runtime/PosedBone.cs
+++ b/Runtime/PosedBone.cs
@@ -19,7 +19,7 @@ namespace FrozenAPE
         public string targetBone;
 
         /// <summary>
-        /// bone position
+        /// local bone position, i.e. relative to parent bone
         /// </summary>
         public double3? position;
 

--- a/Runtime/PosedBone.cs
+++ b/Runtime/PosedBone.cs
@@ -24,7 +24,7 @@ namespace FrozenAPE
         public double3? position;
 
         /// <summary>
-        /// bone rotation (Euler angles)
+        /// local bone rotation (Euler angles), i.e. relative to parent bone
         /// </summary>
         public double3? rotation;
 

--- a/Runtime/PosedBone.cs
+++ b/Runtime/PosedBone.cs
@@ -29,7 +29,7 @@ namespace FrozenAPE
         public double3? rotation;
 
         /// <summary>
-        /// bone scaling
+        /// local bone scaling, i.e. relative to parent bone
         /// CANNOT BE 0
         /// </summary>
         public double3? scaling;

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -57,7 +57,7 @@ namespace FrozenAPE
             {
                 PosedBone posedBone = new();
                 posedBone.targetBone = transform.name;
-                posedBone.rotation = (float3)transform.eulerAngles;
+                posedBone.rotation = (float3)transform.localEulerAngles;
                 posedBone.position = (float3)transform.position;
                 posedBone.scaling = (float3)transform.localScale;
 

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -30,9 +30,9 @@ namespace FrozenAPE
 
                 if (posedBone.position is not null)
                 {
-                    Debug.Log($"\tposing `{transforms[idx].name}` position {transforms[idx].position} to {posedBone.position}");
-                    transforms[idx].position = (Vector3)math.float3((double3)posedBone.position!);
-                    Debug.Log($"\t`{transforms[idx].name}` position is now {transforms[idx].position}");
+                    Debug.Log($"\tposing `{transforms[idx].name}` position {transforms[idx].localPosition} to {posedBone.position}");
+                    transforms[idx].localPosition = (Vector3)math.float3((double3)posedBone.position!);
+                    Debug.Log($"\t`{transforms[idx].name}` position is now {transforms[idx].localPosition}");
                 }
 
                 if (posedBone.scaling is not null)

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -58,7 +58,7 @@ namespace FrozenAPE
                 PosedBone posedBone = new();
                 posedBone.targetBone = transform.name;
                 posedBone.rotation = (float3)transform.localEulerAngles;
-                posedBone.position = (float3)transform.position;
+                posedBone.position = (float3)transform.localPosition;
                 posedBone.scaling = (float3)transform.localScale;
 
                 posedBoneList.Add(posedBone);

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -23,9 +23,9 @@ namespace FrozenAPE
                 Debug.Log($"applying pose for bone `{posedBone.targetBone}` [{transforms[idx].name}]");
                 if (posedBone.rotation is not null)
                 {
-                    Debug.Log($"\tposing `{transforms[idx].name}` rotation {transforms[idx].eulerAngles} to {posedBone.rotation}");
-                    transforms[idx].eulerAngles = (Vector3)math.float3((double3)posedBone.rotation!);
-                    Debug.Log($"\t`{transforms[idx].name}` rotation is now {transforms[idx].eulerAngles}");
+                    Debug.Log($"\tposing `{transforms[idx].name}` rotation {transforms[idx].localEulerAngles} to {posedBone.rotation}");
+                    transforms[idx].localEulerAngles = (Vector3)math.float3((double3)posedBone.rotation!);
+                    Debug.Log($"\t`{transforms[idx].name}` rotation is now {transforms[idx].localEulerAngles}");
                 }
 
                 if (posedBone.position is not null)

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -73,7 +73,7 @@ namespace FrozenAPE
 
             foreach (var transform in transforms)
             {
-                transform.eulerAngles = (float3)transform.eulerAngles + random.NextFloat3(-30, 30);
+                transform.localEulerAngles = (float3)transform.localEulerAngles + random.NextFloat3(-30, 30);
                 transform.position = (float3)transform.position + random.NextFloat3(-0.1f, 0.1f);
                 transform.localScale = (float3)transform.localScale * random.NextFloat3(0.9f, 1.1f);
             }

--- a/Runtime/RigPuppeteer.cs
+++ b/Runtime/RigPuppeteer.cs
@@ -74,7 +74,7 @@ namespace FrozenAPE
             foreach (var transform in transforms)
             {
                 transform.localEulerAngles = (float3)transform.localEulerAngles + random.NextFloat3(-30, 30);
-                transform.position = (float3)transform.position + random.NextFloat3(-0.1f, 0.1f);
+                transform.localPosition = (float3)transform.localPosition + random.NextFloat3(-0.1f, 0.1f);
                 transform.localScale = (float3)transform.localScale * random.NextFloat3(0.9f, 1.1f);
             }
         }

--- a/Runtime/RigVerifier.cs
+++ b/Runtime/RigVerifier.cs
@@ -52,7 +52,7 @@ namespace FrozenAPE
 
                 if (posedBone.position is not null)
                 {
-                    double3 transform_position = (float3)transform.position;
+                    double3 transform_position = (float3)transform.localPosition;
                     int3 transform_position_comparand = (int3)(transform_position * k_CutoffPrecision);
                     int3 posedBone_position_comparand = (int3)(posedBone.position * k_CutoffPrecision);
 
@@ -66,7 +66,7 @@ namespace FrozenAPE
                         Debug.LogError(
                             $"position mismatch for `{posedBone.targetBone}`: {match}"
                                 + $"\n Posed Bone position is {posedBone.position}"
-                                + $"\n transform position is {transform.position}"
+                                + $"\n transform position is {transform.localPosition}"
                         );
                 }
 

--- a/Runtime/RigVerifier.cs
+++ b/Runtime/RigVerifier.cs
@@ -32,7 +32,7 @@ namespace FrozenAPE
 
                 if (posedBone.rotation is not null)
                 {
-                    double3 transform_angles = (float3)transform.eulerAngles;
+                    double3 transform_angles = (float3)transform.localEulerAngles;
                     int3 transform_angles_comparand = (int3)(transform_angles * k_CutoffPrecision);
                     int3 posedBone_rotation_comparand = (int3)(posedBone.rotation * k_CutoffPrecision);
 
@@ -46,7 +46,7 @@ namespace FrozenAPE
                         Debug.LogError(
                             $"rotation mismatch for `{posedBone.targetBone}`: {match}"
                                 + $"\n Posed Bone rotation is {posedBone.rotation}"
-                                + $"\n transform rotation is {transform.eulerAngles}"
+                                + $"\n transform rotation is {transform.localEulerAngles}"
                         );
                 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kagekirin.frozenape",
-  "version": "0.3.7",
+  "version": "0.4.0-0",
   "displayName": "Frozen A-Pose Exporter 🧊🦍",
   "description": "Editor and Runtime exporter for skinned meshes frozen in a specific pose as static mesh",
   "unity": "2022.3",


### PR DESCRIPTION
- **doc (PosedBone): change documentation for .position to precise it is the 'local' position**
- **doc (PosedBone): change documentation for .rotation to precise it is the 'local' rotation**
- **doc (PosedBone): change documentation for .scaling to precise it is the 'local' scale**
- **refactor (RigPuppeteer): apply PosedBone.rotation to transform local rotation in .Pose()**
- **refactor (RigPuppeteer): apply PosedBone.position to transform local position in .Pose()**
- **refactor (RigPuppeteer): save PosedBone.rotation from transform local rotation (Euler angles) in .SavePose()**
- **refactor (RigPuppeteer): save PosedBone.position from transform local position in .SavePose()**
- **refactor (RigPuppeteer): set PosedBone.rotation from randomized transform local rotation (Euler angles) in .RandomizePose()**
- **refactor (RigPuppeteer): set PosedBone.position from randomized transform local position in .RandomizePose()**
- **refactor (RigVerifier): compare PosedBone.rotation with transform local rotation (Euler angles)**
- **refactor (RigVerifier): compare PosedBone.position with transform local position**
- **build (package.json): prebump version to 0.4.0**


**ΝΟΤΕ**: breaking change regarding previously saved pose data