### PR TITLE
refactor (Runtime): handle potential null returned from TextureX.GetPixelData() in BaseTextureWriter.WriteTexture()

### DIFF
--- a/Runtime/BaseTextureWriter.cs
+++ b/Runtime/BaseTextureWriter.cs
@@ -32,14 +32,18 @@ namespace FrozenAPE
                 texture_depth = (uint)(texture as Texture2DArray).depth;
             }
 
-            using NativeArray<byte> bytes = EncodingFunc(
-                imageBytes,
-                texture.graphicsFormat,
-                (uint)texture.width,
-                (uint)texture.height * texture_depth,
-                0
-            );
-            return bytes.ToArray();
+            if (imageBytes != null && imageBytes.Length > 0)
+            {
+                using NativeArray<byte> bytes = EncodingFunc(
+                    imageBytes,
+                    texture.graphicsFormat,
+                    (uint)texture.width,
+                    (uint)texture.height * texture_depth,
+                    0
+                );
+                return bytes.ToArray();
+            }
+            return Array.Empty<byte>();
         }
 
         public string NameTexture(Texture texture)


### PR DESCRIPTION
note: prior handling (i.e. no handling at all) resulted in crash when the NativeArray<byte> returned from each of the Texture.GetPixelData<byte>() is null.
      we added a null-check before passing the data to the EncodingFunc() to bypass null pointer access issues.
