### PR TITLE
refactor (Runtime): handle potential null NativeArray<byte> returned from EncodingFunc() in BaseTextureWriter.WriteTexture()

### DIFF
--- a/Runtime/BaseTextureWriter.cs
+++ b/Runtime/BaseTextureWriter.cs
@@ -80,7 +80,9 @@ namespace FrozenAPE
                     (uint)texture.height * texture_depth,
                     0
                 );
-                return bytes.ToArray();
+
+                if (bytes != null && bytes.Length > 0)
+                    return bytes.ToArray();
             }
             return Array.Empty<byte>();
         }


### PR DESCRIPTION
note: prior handling (i.e. no handling at all) resulted in crash when transforming the NativeArray<byte> returned from the EncodingFunc() into a regular byte-array.
