### PR TITLE
refactor (Runtime): simplify BaseTextureWriter.WriteTexture()

### DIFF
--- a/Runtime/BaseTextureWriter.cs
+++ b/Runtime/BaseTextureWriter.cs
@@ -167,5 +167,54 @@ namespace FrozenAPE
             NativeArray<byte> empty = default;
             return empty;
         }
+
+        /// <summary>
+        /// fetches pixels from the given texture using .GetPixels32()
+        /// returns a native array containing the data
+        /// </summary>
+        /// <param name="texture">texture to read (must be set to readable)</param>
+        /// <returns>native array containing the data</returns>
+        protected virtual NativeArray<byte> FetchPixels(Texture texture)
+        {
+            Debug.Log("fetching data through Texture.GetPixels32()");
+
+            try
+            {
+                Color32[] colors = default;
+                if (texture is Texture2D)
+                {
+                    colors = (texture as Texture2D).GetPixels32(miplevel: 0);
+                }
+                else if (texture is Texture3D)
+                {
+                    colors = (texture as Texture3D).GetPixels32(miplevel: 0);
+                }
+                else if (texture is Texture2DArray)
+                {
+                    colors = (texture as Texture2DArray).GetPixels32(miplevel: 0, arrayElement: 0);
+                }
+
+                if (colors != null && colors.Length > 0)
+                {
+                    int textureDepth = GetTextureDepth(texture);
+                    NativeArray<byte> imageBytes = new NativeArray<byte>(colors.Length * textureDepth * 4, Allocator.Persistent);
+                    for (int i = 0; i < colors.Length * textureDepth; i++)
+                    {
+                        imageBytes[i * 4 + 0] = colors[i].r;
+                        imageBytes[i * 4 + 1] = colors[i].g;
+                        imageBytes[i * 4 + 2] = colors[i].b;
+                        imageBytes[i * 4 + 3] = colors[i].a;
+                    }
+                    return imageBytes;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"failed to access texture data using Texture.GetPixels32(): {ex}");
+            }
+
+            NativeArray<byte> empty = default;
+            return empty;
+        }
     }
 }

--- a/Runtime/BaseTextureWriter.cs
+++ b/Runtime/BaseTextureWriter.cs
@@ -116,5 +116,22 @@ namespace FrozenAPE
             uint, //< rowBytes
             NativeArray<byte> //< return
         > EncodingFunc { get; }
+
+        /// <summary>
+        /// retrieves the texture's depth (3D: depth, 2DArray: #slices)
+        /// defaults to 1 for 1D/2D textures
+        /// </summary>
+        /// <param name="texture">texture to get data from</param>
+        /// <returns>texture depth/#slices if applicable, else 1</returns>
+        protected virtual int GetTextureDepth(Texture texture)
+        {
+            if (texture is Texture3D)
+                return (texture as Texture3D).depth;
+
+            if (texture is Texture2DArray)
+                return (texture as Texture2DArray).depth;
+
+            return 1;
+        }
     }
 }

--- a/Runtime/BaseTextureWriter.cs
+++ b/Runtime/BaseTextureWriter.cs
@@ -133,5 +133,39 @@ namespace FrozenAPE
 
             return 1;
         }
+
+        /// <summary>
+        /// fetches pixels from the given texture using .GetPixelData()
+        /// returns a native array containing the data
+        /// </summary>
+        /// <param name="texture">texture to read (must be set to readable)</param>
+        /// <returns>native array containing the data</returns>
+        protected virtual NativeArray<byte> FetchPixelsFast(Texture texture)
+        {
+            Debug.Log("fetching data through Texture.GetPixelData()");
+
+            try
+            {
+                if (texture is Texture2D)
+                {
+                    return (texture as Texture2D).GetPixelData<byte>(mipLevel: 0);
+                }
+                else if (texture is Texture3D)
+                {
+                    return (texture as Texture3D).GetPixelData<byte>(mipLevel: 0);
+                }
+                else if (texture is Texture2DArray)
+                {
+                    return (texture as Texture2DArray).GetPixelData<byte>(mipLevel: 0, element: 0);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"failed to access texture data using Texture.GetPixelData<byte>(): {ex}");
+            }
+
+            NativeArray<byte> empty = default;
+            return empty;
+        }
     }
 }


### PR DESCRIPTION
- **refactor (Runtime): extract texture depth retrieval into BaseTextureWriter.GetTextureDepth()**
- **refactor (Runtime): extract texture data retrieval via Texture.GetPixelData() into BaseTextureWriter.FetchPixelsFast()**
- **refactor (Runtime): extract texture data retrieval via Texture.GetPixels32() into BaseTextureWriter.FetchPixels()**
- **refactor (Runtime): simplify BaseTextureWriter.WriteTexture() to call extracted methods**
